### PR TITLE
prevent the autosize triggering a scroll event

### DIFF
--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -54,6 +54,7 @@ export class AutosizeDirective implements AfterContentChecked {
             const clone = this.textAreaEl.cloneNode(true);
             const parent = this.textAreaEl.parentNode;
             clone.style.visibility = 'hidden';
+            clone.style.display = 'fixed';
             parent.appendChild(clone);
 
             clone.style.overflow = 'auto';


### PR DESCRIPTION
prevent the autosize triggering a scroll event in the page by giving the clone element a fixed position