### PR TITLE
Add option to force CSS !important

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Name  | Default | Type | Description
 minRows | | integer | Sets minimal amount of rows of the textarea
 maxRows | | integer | Sets maximum rows count after which autosizing if turned off and scrollbar appears
 onlyGrow | false | boolean | Controls if autosize should make the textarea smaller. In other words... should empty lines be trimmed?
+useImportant | false | boolean | Controls if autosize should include `!important` in its height css styles. Should only need to be used if the height of the textarea is being overridden elsewhere
 
 Example
 ```

--- a/projects/autosize/src/lib/autosize.directive.ts
+++ b/projects/autosize/src/lib/autosize.directive.ts
@@ -18,7 +18,8 @@ const MAX_LOOKUP_RETRIES = 3;
 export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChecked {
     @Input() minRows: number;
     @Input() maxRows: number;
-    @Input() onlyGrow: boolean = false;
+    @Input() onlyGrow = false;
+    @Input() useImportant = false;
 
     private retries = 0;
     private textAreaEl: any;
@@ -102,7 +103,7 @@ export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChec
         });
         setTimeout(() => {
             this.adjust();
-        })
+        });
     }
 
     adjust(inputsChanged = false): void {
@@ -135,18 +136,25 @@ export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChec
             if (this.onlyGrow === false || willGrow) {
                 const lineHeight = this._getLineHeight();
                 const rowsCount = height / lineHeight;
+
+                let styleAttribute = '';
+
                 if (this.minRows && this.minRows >= rowsCount) {
                     height = this.minRows * lineHeight;
 
                 } else if (this.maxRows && this.maxRows <= rowsCount) {
                     height = this.maxRows * lineHeight;
-                    this.textAreaEl.style.overflow = 'auto';
+                    styleAttribute += 'overflow: auto;';
 
                 } else {
-                    this.textAreaEl.style.overflow = 'hidden';
+                    styleAttribute += 'overflow: hidden;';
                 }
 
-                this.textAreaEl.style.height = height + 'px';
+                styleAttribute += `height: ${height}px`;
+
+                styleAttribute += this.useImportant ? '!important;' : ';';
+
+                this.textAreaEl.setAttribute('style', styleAttribute);
             }
 
             parent.removeChild(clone);


### PR DESCRIPTION
While working on a project, I came across a problem where the height of my given textarea was being forced to `height: auto !important` by the Reboot.css file from Bootstrap. There was no way that I could get this package (or similar packages) to work short of manually adding the `!important` tag after the package had made its calculation.

This commit updates the component to add a `useImportant` option. It's defaulted to `false` but, if set to `true` the component will add the `!important` tag to the height calculation to force the height necessary. The string-building and `setAttribute` changes were necessary to set the property cross-browser and to work with frameworks like Material.