### PR TITLE
Fix onlyGrow so that it takes precedence over maxRows consistently

### DIFF
--- a/projects/autosize/src/lib/autosize.directive.ts
+++ b/projects/autosize/src/lib/autosize.directive.ts
@@ -148,7 +148,8 @@ export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChec
             height += parseInt(computedStyle.getPropertyValue('border-top-width'));
             height += parseInt(computedStyle.getPropertyValue('border-bottom-width'));
 
-            const willGrow = height > this.textAreaEl.offsetHeight;
+            const oldHeight = this.textAreaEl.offsetHeight;
+            const willGrow = height > oldHeight;
 
             if (this.onlyGrow === false || willGrow) {
                 const lineHeight = this._getLineHeight();
@@ -158,7 +159,9 @@ export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChec
                     height = this._minRows * lineHeight;
 
                 } else if (this.maxRows && this.maxRows <= rowsCount) {
-                    height = this.maxRows * lineHeight;
+                    // never shrink the textarea if onlyGrow is true
+                    const maxHeight = this.maxRows * lineHeight;
+                    height = this.onlyGrow ? Math.max(maxHeight, oldHeight): maxHeight;
                     this.textAreaEl.style.overflow = 'auto';
 
                 } else {


### PR DESCRIPTION
If both onlyGrow and maxRows are set, AND there is enough content in a textarea that willGrow evaluates to true, AND a user has expanded the textarea to larger than maxRows, ngx-autosize will currently shrink the height down to maxRows.

I think it is better that onlyGrow is always respected. If a user expands a textarea to whatever size they like, we shouldn't be second guessing that with maxHeight.

This patches the behavior, although perhaps a less confusing fix would be to ensure that willGrow doesn't evaluate as true in cases where autosize actually intends to shrink the window. 