### PR TITLE
Fix: Make sure the cloned textarea starts with 1 row

### DIFF
--- a/projects/autosize/src/lib/autosize.directive.ts
+++ b/projects/autosize/src/lib/autosize.directive.ts
@@ -131,6 +131,7 @@ export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChec
 
             const clone = this.textAreaEl.cloneNode(true);
             const parent = this.textAreaEl.parentNode;
+            clone.rows = 1;
             clone.style.width = this.textAreaEl.offsetWidth + 'px';
             clone.style.visibility = 'hidden';
             clone.style.position = 'absolute';


### PR DESCRIPTION
In all my tests the cloned textarea starts with 2 rows. This causes the computed height to always be at least 2 rows, which causes the real textarea to never be smaller than 2 rows. This is problematic when one wishes to have a textarea with minRows==1.

This PR fixes that by forcing the cloned textarea rows to 1.