### PR TITLE
Update public-api.ts

### DIFF
--- a/projects/ngx-autosize/src/public-api.ts
+++ b/projects/ngx-autosize/src/public-api.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/autosize.directive';
 export * from './lib/autosize.module';
+export * from './lib/window-ref.service.ts';


### PR DESCRIPTION
Export window-ref.service.ts; If the user has not interacted with the screen, WindowsRef has not been loaded and it causes an error.