### PR TITLE
fix(): wrong height calculation when textarea has a padding

### DIFF
--- a/projects/ngx-autosize/src/lib/autosize.directive.ts
+++ b/projects/ngx-autosize/src/lib/autosize.directive.ts
@@ -159,10 +159,10 @@ export class AutosizeDirective implements OnDestroy, OnChanges, AfterContentChec
             height += parseInt(computedStyle.getPropertyValue('border-top-width'));
             height += parseInt(computedStyle.getPropertyValue('border-bottom-width'));
 
-            // add into height top and bottom paddings width
-            height += parseInt(computedStyle.getPropertyValue('padding-top'));
-            height += parseInt(computedStyle.getPropertyValue('padding-bottom'));
-
+            if (computedStyle.getPropertyValue('box-sizing') === 'content-box') {
+                height -= parseInt(computedStyle.getPropertyValue('padding-top'));
+                height -= parseInt(computedStyle.getPropertyValue('padding-bottom'));
+            }
 
             const oldHeight = this.textAreaEl.offsetHeight;
             const willGrow = height > oldHeight;


### PR DESCRIPTION
do not add "padding-top" and "padding-bottom"; subtract them when "box-sizing" is "content-box"

Fixes #103 